### PR TITLE
Added full .idea folder to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,7 @@
 *.iml
 .gradle
 /local.properties
-/.idea/caches
-/.idea/libraries
-/.idea/modules.xml
-/.idea/workspace.xml
-/.idea/navEditor.xml
-/.idea/assetWizardSettings.xml
+/.idea
 .DS_Store
 /build
 /captures


### PR DESCRIPTION
При открытии проекта в Android Studio, часть файлов в .idea не оказываются в гитигноре, но самой папки в проекте так же нет, эти файлы не были закоммичены. Полагаю, лучше всю папку добавить в гитигнор.